### PR TITLE
Adding dummy Andor implementation as fallback when we cannot import the real thing. Using Evora to get the current temperature in the /temperature Flask route.

### DIFF
--- a/evora/andor/__init__.py
+++ b/evora/andor/__init__.py
@@ -1,0 +1,5 @@
+
+try:
+    from .andor import *
+except ImportError:
+    from .dummy import *

--- a/evora/andor/dummy.py
+++ b/evora/andor/dummy.py
@@ -1,0 +1,136 @@
+from PIL import Image
+from numpy import asarray
+import base64
+from io import BytesIO
+from random import randint
+
+# Replacement constants, taken from atmcdLXd.h
+DRV_SUCCESS = 20002
+DRV_TEMPERATURE_OFF = 20034
+DRV_TEMPERATURE_STABILIZED = 20036
+DRV_NOT_INITIALIZED = 20075
+DRV_ACQUIRING = 0
+
+"""
+SWIG notes
+SWIG seems to change the API from the docs in two major ways
+1. Unsigned int functions actually return [status, return_val] e.g. [DRV_SUCCESS, 35]
+2. Pointer arguments are simply omitted e.g. int SomeFunction(long* input) -> def SomeFunction()...
+"""
+
+
+# Andor SDK replacement functions with return values
+def GetStatus():
+    return [DRV_NOT_INITIALIZED, 0]
+
+
+def GetAvailableCameras():
+    return 1
+
+
+def GetCameraHandle(cameraIndex):
+    return [DRV_SUCCESS, 1]
+
+
+def Initialize(directory):
+    return 1
+
+
+def GetTemperatureF():
+    return [DRV_SUCCESS, 32]
+
+
+def GetTemperatureStatus():
+    return [DRV_SUCCESS, 1]
+
+
+def GetTemperatureRange(mintemp, maxtemp):
+    return maxtemp - mintemp
+
+
+# Acquisition
+def StartAcquisition():
+    DRV_ACQUIRING = 1
+
+
+def AbortAcquisition():
+    DRV_ACQUIRING = 0
+
+
+def GetAcquiredData16(write_var):
+    img = 'space.txt'
+    if randint(0, 1000) >= 999:
+        img = 'space0.txt'
+
+    with open(img) as f:
+        data = asarray(Image.open(BytesIO(base64.b64decode(f.read()))))
+
+    # This might not work, passing by reference is weird in Python
+    write_var = data
+    return DRV_SUCCESS
+
+
+# These functions do the same thing in this context
+GetMostRecentImage16 = GetAcquiredData16
+
+
+def GetAcquisitionTimings(exposure, accumulate, kinetic):
+    return 1
+
+
+def GetNumberVSSpeeds(speeds):
+    return 1
+
+
+def GetNumberVSAmplitudes(number):
+    return 1
+
+
+def GetVSSpeed(index, speed):
+    return 1
+
+
+def GetFastestRecommendedVSSpeed(index, speeds):
+    return 1
+
+
+def GetNumberHSSpeeds(channel, typ, speeds):
+    return 1
+
+
+def GetHSSpeed(channel, typ, index, speed):
+    return 1
+
+
+def GetDetector(xpixels, ypixels):
+    return 1
+
+
+def GetAcquisitionProgress(acc, series):
+    return 1
+
+
+# Setter functions
+def noop(*args):
+    # Takes any number of arguments, does nothing
+    pass
+
+
+# Set to noop func instead of defining each to save space
+SetCurrentCamera = noop
+SetAcquisitionMode = noop
+SetTemperature = noop
+SetShutter = noop
+SetFanMode = noop
+CoolerOFF = noop
+CoolerON = noop
+Shutdown = noop
+SetReadMode = noop
+SetImage = noop
+SetShutter = noop
+SetExposureTime = noop
+SetKineticCycleTime = noop
+SetNumberAccumulations = noop
+SetAccumulationCycleTime = noop
+SetNumberKinetics = noop
+SetTriggerMode = noop

--- a/evora/evora.py
+++ b/evora/evora.py
@@ -1,3 +1,6 @@
+from evora import andor
+
+
 class Evora(object):
     """
     This class executes the driver code through the "andor" import which is "swigged" C++ code.

--- a/main.py
+++ b/main.py
@@ -1,15 +1,6 @@
 from flask import Flask
 app = Flask(__name__)
 
-import glob # used only in Evora.getHeader
-import os # used only in Evora.chooseLogFile
-import time
-
-import evora.common.utils.fits as fits_utils # TODO: edit path structure later
-import numpy as np
-import pandas as pd
-from astropy.io import fits
-from astropy.time import Time
 from evora.evora import Evora 
 
 try:
@@ -26,10 +17,7 @@ def index():
 # REMEMBER: localhost:5000/temperature
 @app.route('/temperature')
 def route_temperature():
-    e = Evora()
-    andor_temp = 0  # add something here to output the actual temperature
-    # limitation: does not update realtime
-    return '{}°C'.format(andor_temp)
+    return Evora().getTemp()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The dummy Andor implementation is mostly lifted from the old codebase.

I did the import in __init__ so that instead of having the try/except logic in each place that uses Andor we have it in one place that everything can use transparently.

I'll have more changes to the Flask app in a separate PR, but I wanted to make a minimal change as a proof of concept of the dummy Andor implementation.