### PR TITLE
Do not use PORT=3001 since it does not work in Windows

### DIFF
--- a/uwmro-client/package.json
+++ b/uwmro-client/package.json
@@ -14,7 +14,7 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "PORT=3001 react-scripts start",
+    "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",


### PR DESCRIPTION
Removes `PORT=3001` from `package.json` since it won't work in Windows and there's no syntax for specifying the environment variable that will work at the same time in Windows and Linux.

The client will default to port 3000 so some documentation may need to change.